### PR TITLE
Running install.sh without the absolute path for OpenNI. (#231)

### DIFF
--- a/provisioning/modules/repo_dependencies/manifests/daq_dependencies.pp
+++ b/provisioning/modules/repo_dependencies/manifests/daq_dependencies.pp
@@ -95,8 +95,9 @@ class repo_dependencies::daq_dependencies {
     ->
 
     exec { "install_openni":
-        command => "/bin/bash /tmp/OpenNI-Bin-Dev-Linux-x64-v1.5.4.0/install.sh",
-        cwd => "/tmp/OpenNI-Bin-Dev-Linux-x64-v1.5.4.0"
+        command => "/bin/bash install.sh",
+        cwd => "/tmp/OpenNI-Bin-Dev-Linux-x64-v1.5.4.0",
+        logoutput => true
     }
 
 }


### PR DESCRIPTION
It does some brain-damaged path-related hacks in it and fucks up
installation when ran like this.
